### PR TITLE
chtnau8824: add speaker volume and keep 0 db

### DIFF
--- a/chtnau8824/HiFi.conf
+++ b/chtnau8824/HiFi.conf
@@ -139,6 +139,9 @@ SectionVerb {
 		cset "name='DMIC4 Enable Switch' off"
 		cset "name='MIC1 Volume' 10"
 		cset "name='MIC2 Volume' 5"
+		# Output Configuration
+		cset "name='Speaker Right DACR Volume' 1"
+		cset "name='Speaker Left DACL Volume' 1"
 
 	]
 


### PR DESCRIPTION
Unmute speaker to avoid no sound when switching to speaker.
And keep the volume to 0db for common case.

Signed-off-by: John Hsu <KCHSU0@nuvoton.com>