### PR TITLE
DMIC was tested on Lenovo Miix2 8

### DIFF
--- a/bytcr-rt5640/HiFi
+++ b/bytcr-rt5640/HiFi
@@ -158,7 +158,7 @@ SectionVerb {
 }
 
 SectionDevice."DigitalMics" {
-	Comment "DigitalMics capture, NOT TESTED"
+	Comment "DigitalMics capture"
 
 	ConflictingDevice [
 		"IN1-InternalMics"

--- a/sof-bytcr-rt5640/HiFi
+++ b/sof-bytcr-rt5640/HiFi
@@ -50,7 +50,7 @@ SectionVerb {
 }
 
 SectionDevice."DigitalMics" {
-	Comment "DigitalMics capture, NOT TESTED"
+	Comment "DigitalMics capture"
 
 	ConflictingDevice [
 		"IN1-InternalMics"


### PR DESCRIPTION
DMIC was tested on Lenovo Miix2 8, so let's remove "NOT TESTED" from DMIC description.