### PR TITLE
chtnau8824: support button configuration

### DIFF
--- a/chtnau8824/HiFi.conf
+++ b/chtnau8824/HiFi.conf
@@ -142,7 +142,11 @@ SectionVerb {
 		# Output Configuration
 		cset "name='Speaker Right DACR Volume' 1"
 		cset "name='Speaker Left DACL Volume' 1"
-
+		# Button Configuration
+		cset "name='THD for key media' 10"
+		cset "name='THD for key voice command' 20"
+		cset "name='THD for key volume up' 38"
+		cset "name='THD for key volume down' 115"
 	]
 
 	DisableSequence [


### PR DESCRIPTION
The SAR ADC of key press detection varies depending on headset.
We can't make a set of common threshold values for every case.
Therefore, the UCM config provides configuration for user
and they can set up values by it.

Signed-off-by: John Hsu <KCHSU0@nuvoton.com>