### PR TITLE
chtnau8824: Internal mic is on ch0, headset mic on ch1

### DIFF
--- a/chtnau8824/HiFi.conf
+++ b/chtnau8824/HiFi.conf
@@ -129,9 +129,6 @@ SectionVerb {
 		# Playback TDM configuration
 		cset "name='DACL Channel Source' 0"
 		cset "name='DACR Channel Source' 1"
-		# Capture TDM configuration
-		cset "name='ADC CH0 Select' 0"
-		cset "name='ADC CH1 Select' 1"
 		# Input Configuration
 		cset "name='DMIC1 Enable Switch' off"
 		cset "name='DMIC2 Enable Switch' off"
@@ -235,6 +232,9 @@ SectionDevice."InternalMic" {
 	EnableSequence [
 		cdev "hw:chtnau8824"
 
+		cset "name='ADC CH0 Select' 0"
+		cset "name='ADC CH1 Select' 0"
+
 		cset "name='Int Mic Switch' on"
 		cset "name='Right ADC MIC Switch' on"
 		cset "name='Left ADC MIC Switch' on"
@@ -263,6 +263,9 @@ SectionDevice."HeadsetMic" {
 
 	EnableSequence [
 		cdev "hw:chtnau8824"
+
+		cset "name='ADC CH0 Select' 1"
+		cset "name='ADC CH1 Select' 1"
 
 		cset "name='Headset Mic Switch' on"
 		cset "name='Right ADC HSMIC Switch' on"


### PR DESCRIPTION
Both tablets I have with a nau8824 codec, the Cube iWork8 Air and the
Pipo W2s, have their iInternal mic on ch0 and their headset mic on ch1.

Fix recordings from the internal mic only having sound on the left
channel and from the headset-mic only having sound on the right channel.

Signed-off-by: Hans de Goede <hdegoede@redhat.com>