### PR TITLE
Correct typo in speaker conflicting device

### DIFF
--- a/chtnau8824/HiFi.conf
+++ b/chtnau8824/HiFi.conf
@@ -176,7 +176,7 @@ SectionDevice."Speaker" {
 	}
 
 	ConflictingDevice [
-		"Headphone"
+		"Headphones"
 	]
 
 	EnableSequence [


### PR DESCRIPTION
Makes headphone connection switch off the speakers properly.