### PR TITLE
sof-skl_hda_card: add generic HDA configuration

### DIFF
--- a/sof-skl_hda_card/HiFi
+++ b/sof-skl_hda_card/HiFi
@@ -1,0 +1,166 @@
+# Use case Configuration for skl-hda-card
+
+SectionVerb {
+
+	EnableSequence [
+		cdev "hw:sofsklhdacard"
+		cset "name='Master Playback Switch' on"
+		cset "name='Master Playback Volume' 80"
+		cset "name='Capture Switch' on"
+		cset "name='Input Source' 1"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsklhdacard"
+		cset "name='Master Playback Switch' off"
+		cset "name='Capture Switch' off"
+		cset "name='Input Source' 0"
+	]
+}
+
+SectionDevice."Headphone" {
+	Comment "Headphone"
+
+	ConflictingDevice [
+                "Speaker"
+        ]
+	
+	EnableSequence [
+		cdev "hw:sofsklhdacard"
+		cset "name='Headphone Playback Volume' 80"
+		cset "name='Headphone Mic Boost Volume' 1"
+		cset "name='Headphone Playback Switch' on"
+                cset "name='Speaker Playback Switch' off"
+	]
+
+	DisableSequence [
+		cdev "hw:sofsklhdacard"
+		cset "name='Headphone Playback Switch' off"
+	]
+
+	Value {
+		PlaybackPCM "hw:sofsklhdacard,0"
+		PlaybackChannels "2"
+		JackHWMute "Speaker"
+		JackControl "Headphone Mic Jack"
+	}
+}
+
+SectionDevice."Speaker" {
+        Comment "Speaker"
+
+        ConflictingDevice [
+                "Headphone"
+        ]
+
+        EnableSequence [
+                cdev "hw:sofsklhdacard"
+                cset "name='Speaker Playback Switch' on"
+                cset "name='Speaker Playback Volume' 81"
+		cset "name='Headphone Playback Switch' off"
+        ]
+
+        DisableSequence [
+                cset "name='Speaker Playback Switch' off"
+        ]
+
+        Value {
+		PlaybackPCM "hw:sofsklhdacard,0"
+		PlaybackChannels "2"
+		JackHWMute "Headphone"
+        }
+}
+
+SectionDevice."Microphone" {
+	Comment "Headset Mic"
+
+        EnableSequence [
+                cdev "hw:sofsklhdacard"
+        ]
+
+        DisableSequence [
+                cdev "hw:sofsklhdacard"
+        ]
+
+        Value {
+		CapturePCM "hw:sofsklhdacard,0"
+                CaptureChannels "2"
+		JackControl "Headphone Mic Jack"
+        }
+}
+
+SectionDevice."Dmic" {
+        Comment "Digital Micrphone"
+
+        EnableSequence [
+                cdev "hw:sofsklhdacard"
+                cset "name='PGA10.0 10 Master Capture Volume' 75"
+        ]
+
+        DisableSequence [
+                cdev "hw:sofsklhdacard"
+        ]
+
+        Value {
+		CapturePCM "hw:sofsklhdacard,6"
+                CaptureChannels "2"
+        }
+}
+
+SectionDevice."HDMI1" {
+        Comment "HDMI1/DP1 Output"
+
+        EnableSequence [
+                cdev "hw:sofsklhdacard"
+                cset "name='IEC958 Playback Switch' on"
+        ]
+
+        DisableSequence [
+                cdev "hw:sofsklhdacard"
+        ]
+
+        Value {
+                PlaybackPCM "hw:0,3"
+                PlaybackChannels "2"
+                JackControl "HDMI/DP,pcm=3 Jack"
+        }
+}
+
+SectionDevice."HDMI2" {
+        Comment "HDMI3/DP3 Output"
+
+        EnableSequence [
+                cdev "hw:sofsklhdacard"
+                cset "name='IEC958 Playback Switch' index=1 on"
+        ]
+
+        DisableSequence [
+                cdev "hw:sofsklhdacard"
+        ]
+
+        Value {
+                PlaybackPCM "hw:0,4"
+                PlaybackChannels "2"
+                JackControl "HDMI/DP,pcm=4 Jack"
+        }
+}
+
+SectionDevice."HDMI3" {
+        Comment "HDMI3/DP3 Output"
+
+        EnableSequence [
+                cdev "hw:sofsklhdacard"
+                cset "name='IEC958 Playback Switch' index=1 on"
+        ]
+
+        DisableSequence [
+                cdev "hw:sofsklhdacard"
+        ]
+
+        Value {
+                PlaybackPCM "hw:0,5"
+                PlaybackChannels "2"
+                JackControl "HDMI/DP,pcm=5 Jack"
+        }
+}
+

--- a/sof-skl_hda_card/README
+++ b/sof-skl_hda_card/README
@@ -1,0 +1,9 @@
+To enable UCM on Intel SOF HDA platforms.
+Matching topology: sof-hda-generic-2ch.tplg
+
+Usage
+-----
+
+1. copy directory to UCM location
+
+sudo cp -rf ../sof-skl_hda_card /usr/share/alsa/ucm


### PR DESCRIPTION
Add a generic configuration matching SOF topology
sof-hda-generic-2ch.tplg (HDA codec, DMIC and HDMI/DP
outputs with DP-MST support).

This UCM file is meant to be used with common HDMI codec
driver (snd_hda_codec_hdmi kernel module) and will
not work when kernel is built and configured to use
SOF with older hdac-hdmi driver.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>