### PR TITLE
Add Syntax 3 to all configurations files

### DIFF
--- a/chtmax98090/HiFi.conf
+++ b/chtmax98090/HiFi.conf
@@ -1,8 +1,8 @@
 # command-line sequence to switch playback/capture
 # alsaucm -c chtmax98090 set _verb HiFi set _enadev Headphone
 # alsaucm -c chtmax98090 set _verb HiFi set _enadev Speakers
-# alsaucm -c chtmax98090 set _verb HiFi set _enadev HeadsetMic
-# alsaucm -c chtmax98090 set _verb HiFi set _enadev InternalMic
+# alsaucm -c chtmax98090 set _verb HiFi set _enadev Headset
+# alsaucm -c chtmax98090 set _verb HiFi set _enadev Mic
 
 
 SectionVerb {
@@ -71,8 +71,8 @@ SectionVerb {
 		cset "name='ADCR Volume' 11"
 		cset "name='ADCL Volume' 11"
 
-		cset "name='Headphone Volume' 10"
-		cset "name='Speaker Volume' 10"
+		cset "name='Headphone Volume' 100"
+		cset "name='Speaker Volume' 100"
 
 		cset "name='Speaker Left Mixer Volume' 3"
 		cset "name='Speaker Right Mixer Volume' 3"
@@ -90,16 +90,6 @@ SectionVerb {
 		cset "name='Headset Mic Switch' off"
 		cset "name='Int Mic Switch' off"
 	]
-
-	DisableSequence [
-	]
-
-	# ALSA PCM
-	Value {
-		# ALSA PCM device for HiFi
-		PlaybackPCM "hw:chtmax98090"
-		CapturePCM  "hw:chtmax98090"
-	}
 }
 
 SectionDevice."Headphone" {
@@ -133,6 +123,7 @@ SectionDevice."Headphone" {
 
 	Value {
 		PlaybackChannels 2
+		PlaybackPCM "hw:chtmax98090"
 	}
 }
 
@@ -160,10 +151,11 @@ SectionDevice."Speakers" {
 
 	Value {
 		PlaybackChannels 2
+		PlaybackPCM "hw:chtmax98090"
 	}
 }
 
-SectionDevice."HeadsetMic" {
+SectionDevice."Headset" {
          Comment "Headset Mic"
 	 
 	 Value {
@@ -172,7 +164,7 @@ SectionDevice."HeadsetMic" {
 	}
 
 	ConflictingDevice [
-		"InternalMic"
+		"Mic"
 	]
 
 	EnableSequence [
@@ -194,10 +186,11 @@ SectionDevice."HeadsetMic" {
 
 	Value {
 		CaptureChannels 2
+		CapturePCM  "hw:chtmax98090"
 	}
 }
 
-SectionDevice."InternalMic" {
+SectionDevice."Mic" {
          Comment "Internal Mic"
 	 
 	 Value {
@@ -205,7 +198,7 @@ SectionDevice."InternalMic" {
 	}
 
 	ConflictingDevice [
-		"HeadsetMic"
+		"Headset"
 	]
 
 	EnableSequence [
@@ -225,6 +218,7 @@ SectionDevice."InternalMic" {
 	]
 
 	Value {
+		CapturePCM  "hw:chtmax98090"
 		CaptureChannels 2
 	}
 }


### PR DESCRIPTION
This is now required by alsaucm. Without this line, the UCM parser
returns the following error:

ALSA lib parser.c:2354:(uc_mgr_scan_master_configs) Syntax field not found in byt-max98090