### PR TITLE
Add Syntax 3 to all configurations files

### DIFF
--- a/byt-max98090/byt-max98090.conf
+++ b/byt-max98090/byt-max98090.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 Comment "Orco internal card"
 
 SectionUseCase."HiFi" {

--- a/byt-rt5640/byt-rt5640.conf
+++ b/byt-rt5640/byt-rt5640.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/bytcht-da7213/bytcht-da7213.conf
+++ b/bytcht-da7213/bytcht-da7213.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/bytcht-nocodec/bytcht-nocodec.conf
+++ b/bytcht-nocodec/bytcht-nocodec.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/bytcht-pcm512x/bytcht-pcm512x.conf
+++ b/bytcht-pcm512x/bytcht-pcm512x.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/bytcr-rt5640/bytcr-rt5640.conf
+++ b/bytcr-rt5640/bytcr-rt5640.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/bytcr-rt5651/bytcr-rt5651.conf
+++ b/bytcr-rt5651/bytcr-rt5651.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 # Adapted from https://github.com/plbossart/UCM/tree/master/bytcr-rt5651
 
 SectionUseCase."HiFi" {

--- a/cht-bsw-rt5672/cht-bsw-rt5672.conf
+++ b/cht-bsw-rt5672/cht-bsw-rt5672.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
     File "HiFi"
     Comment "HiFi Playback & Capture"

--- a/chtmax98090/chtmax98090.conf
+++ b/chtmax98090/chtmax98090.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 Comment "chtmax98090 internal card"
 
 SectionUseCase."HiFi" {

--- a/chtnau8824/chtnau8824.conf
+++ b/chtnau8824/chtnau8824.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 Comment "chtnau8824 internal card"
 
 SectionUseCase."HiFi" {

--- a/chtrt5645/chtrt5645.conf
+++ b/chtrt5645/chtrt5645.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 Comment "Intel SoC Audio Device"
 SectionUseCase."HiFi" {
 	File "HiFi.conf"

--- a/skl_hda_card/skl_hda_card.conf
+++ b/skl_hda_card/skl_hda_card.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/sof-bdw-rt5677/sof-bdw-rt5677.conf
+++ b/sof-bdw-rt5677/sof-bdw-rt5677.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 Comment "Samus internal card"
 
 SectionUseCase."HiFi" {

--- a/sof-bxt-pcm512x/sof-bxt-pcm512x.conf
+++ b/sof-bxt-pcm512x/sof-bxt-pcm512x.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/sof-bxtda7219max/sof-bxtda7219max.conf
+++ b/sof-bxtda7219max/sof-bxtda7219max.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 Comment "sof-bxtda7219max internal card"
 
 SectionUseCase."HiFi" {

--- a/sof-bytcht-da7213/sof-bytcht-da7213.conf
+++ b/sof-bytcht-da7213/sof-bytcht-da7213.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/sof-bytcr-rt5640/sof-bytcr-rt5640.conf
+++ b/sof-bytcr-rt5640/sof-bytcr-rt5640.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi"
 	Comment "Play HiFi quality Music"

--- a/sof-bytcr-rt5651/sof-bytcr-rt5651.conf
+++ b/sof-bytcr-rt5651/sof-bytcr-rt5651.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
 	File "HiFi.conf"
 	Comment "Play HiFi quality Music"

--- a/sof-cht-bsw-rt5672/sof-cht-bsw-rt5672.conf
+++ b/sof-cht-bsw-rt5672/sof-cht-bsw-rt5672.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 SectionUseCase."HiFi" {
     File "HiFi"
     Comment "HiFi Playback & Capture"

--- a/sof-chtmax98090/sof-chtmax98090.conf
+++ b/sof-chtmax98090/sof-chtmax98090.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 Comment "sof-chtmax98090 internal card"
 
 SectionUseCase."HiFi" {

--- a/sof-chtrt5645/sof-chtrt5645.conf
+++ b/sof-chtrt5645/sof-chtrt5645.conf
@@ -1,3 +1,5 @@
+Syntax 3
+
 Comment "SOF chtrt5645 audio device"
 SectionUseCase."HiFi" {
 	File "HiFi.conf"


### PR DESCRIPTION
This is now required by alsaucm. Without this line, the UCM parser
returns the following error:

ALSA lib parser.c:2354:(uc_mgr_scan_master_configs) Syntax field not found in byt-max98090